### PR TITLE
Split x-forwarded-for content without space

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -122,7 +122,7 @@ func (p *Plugin) resolveIP(headers http.Header) string {
 		}
 		// XFF parse
 	} else if fwd := headers.Get(xff); fwd != "" {
-		s := strings.Index(fwd, ", ")
+		s := strings.Index(fwd, ",")
 		if s == -1 {
 			return fwd
 		}

--- a/trusted_test.go
+++ b/trusted_test.go
@@ -18,6 +18,7 @@ func TestIP(t *testing.T) {
 	headers := []headerTable{
 		{xff, "8.8.8.8", "8.8.8.8"},                                   // Single address
 		{xff, "8.8.8.8, 8.8.4.4", "8.8.8.8"},                          // Multiple
+		{xff, "8.8.8.8,8.8.4.4", "8.8.8.8"},                           // Multiple separated without space, ie https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header
 		{xff, "[2001:db8:cafe::17]:4711", "[2001:db8:cafe::17]:4711"}, // IPv6 address
 		{xff, "", ""},                                                  // None
 		{xrip, "8.8.8.8", "8.8.8.8"},                                   // Single address


### PR DESCRIPTION
# Reason for This PR

When enabling this feature in Google Cloud Platform behind a Google Load Balancer, the IP address in roadrunner logs shows as follows:

```
roadrunner 2023-06-08T06:20:16.109Z    INFO    http            http log    {"status": 404, "method": "GET", "URI": "/favicon.ico", "remote_address": "1.2.3.4,5.6.7.8", "read_bytes": 0, "write_bytes": 0, "start": "2023-06-08T06:20:15.993Z", "elapsed": "1ms"}
```

This appears to be becaused the middleware only splits the header by `, `, so comma-space. But Google's loadbalancer separates only using a comma, without space. Source: https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header

> The load balancer appends two IP addresses separated by a single comma to the X-Forwarded-For header

## Description of Changes

Just a small change to allow splitting X-Forwarded-For by both `, ` and `,`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
