### PR TITLE
chore: simplify + modernize (Go 1.26)

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,12 +1,5 @@
 package proxy
 
-import (
-	"net"
-)
-
-// Cidrs is a slice of IPNet addresses
-type Cidrs []*net.IPNet
-
 type Config struct {
 	// TrustedSubnets declare IP subnets which are allowed to set ip using X-Real-Ip and X-Forwarded-For
 	TrustedSubnets []string `mapstructure:"trusted_subnets"`

--- a/plugin.go
+++ b/plugin.go
@@ -27,9 +27,7 @@ const (
 	forwarded string = "Forwarded"
 )
 
-var (
-	forwardedRegex = regexp.MustCompile(`(?i)(?:for=)([^(;|,| )]+)`)
-)
+var forwardedRegex = regexp.MustCompile(`(?i)(?:for=)([^(;|,| )]+)`)
 
 type Logger interface {
 	NamedLogger(name string) *slog.Logger
@@ -107,8 +105,8 @@ func (p *Plugin) Middleware(next http.Handler) http.Handler {
 		}
 
 		ip := net.ParseIP(host)
-		for i := range p.trusted {
-			if p.trusted[i].Contains(ip) {
+		for _, subnet := range p.trusted {
+			if subnet.Contains(ip) {
 				resolvedIP := p.resolveIP(r.Header)
 				if resolvedIP != "" {
 					r.RemoteAddr = resolvedIP
@@ -144,16 +142,9 @@ func (p *Plugin) resolveIP(headers http.Header) string {
 		}
 		// XFF parse
 	} else if fwd := headers.Get(xff); fwd != "" {
-		s := strings.Index(fwd, ",")
-		if s == -1 {
-			return fwd
-		}
-
-		if len(fwd) < s {
-			return ""
-		}
-
-		return fwd[:s]
+		// take the first address; Cut returns the whole string when no comma is present
+		before, _, _ := strings.Cut(fwd, ",")
+		return before
 		// next -> X-Real-Ip
 	} else if fwd := headers.Get(xrip); fwd != "" {
 		return fwd
@@ -173,13 +164,4 @@ func (p *Plugin) resolveIP(headers http.Header) string {
 	}
 
 	return ""
-}
-
-func inc(ip net.IP) {
-	for j := len(ip) - 1; j >= 0; j-- {
-		ip[j]++
-		if ip[j] > 0 {
-			break
-		}
-	}
 }

--- a/trusted_test.go
+++ b/trusted_test.go
@@ -62,3 +62,12 @@ func TestCidrsInRange(t *testing.T) {
 
 	require.Len(t, addrs, 1024)
 }
+
+func inc(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}


### PR DESCRIPTION
Cleanup pass from a multi-plugin review (`/simplify` + `/use-modern-go` Go 1.26 + `/review`).

## Changes
- **Bug/dead code:** `resolveIP` XFF branch had a dead, inverted guard `if len(fwd) < s` (unreachable — `strings.Index` already returned `s >= 0`). Replaced the whole `Index`+slice dance with `strings.Cut`, which returns the full string when no comma is present.
- **Modern Go:** range-over-value (`for _, subnet := range p.trusted`) instead of index loop.
- **Dead code:** removed the unused exported `Cidrs` type (and its now-unused `net` import) from `config.go`.
- **Hygiene:** moved the test-only `inc()` helper into `trusted_test.go`; collapsed a single-entry `var()` block.

## Deps
`go get -u all` (root + tests) and `go work sync` were no-ops — module already current.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified IP header parsing logic for improved efficiency
  * Optimized trusted subnet membership iteration
  * Removed unused exported type from package API

* **Tests**
  * Added test helper for IP iteration validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roadrunner-server/proxy_ip_parser/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
